### PR TITLE
(#13) Add color markup support for form descriptions

### DIFF
--- a/forms/forms.go
+++ b/forms/forms.go
@@ -63,7 +63,7 @@ func (p *Property) RenderedDescription(env map[string]any) (string, error) {
 		return "", err
 	}
 
-	return buffer.String(), nil
+	return colorMarkup(buffer.String()), nil
 }
 
 type processor struct {

--- a/forms/util.go
+++ b/forms/util.go
@@ -6,9 +6,12 @@ package forms
 
 import (
 	"bytes"
-	"github.com/choria-io/scaffold/internal/sprig"
 	"os"
+	"strings"
 	"text/template"
+
+	"github.com/choria-io/scaffold/internal/sprig"
+	"github.com/jedib0t/go-pretty/v6/text"
 
 	"github.com/AlecAivazis/survey/v2"
 	terminal "golang.org/x/term"
@@ -61,5 +64,95 @@ func renderTemplate(tmpl string, env map[string]any) (string, error) {
 		return "", err
 	}
 
-	return out.String(), nil
+	return colorMarkup(out.String()), nil
+}
+
+// colorMarkup parses a string with color markup tags and returns a colorized string.
+// Supports tags like {red}text{/red}, {blue}text{/blue}, etc.
+// Supports all colors available in the go-pretty/text package.
+// Supports nested and multiple color tags in a single string.
+func colorMarkup(input string) string {
+	colorMap := map[string]text.Color{
+		"bold":      text.Bold,
+		"black":     text.FgBlack,
+		"red":       text.FgRed,
+		"green":     text.FgGreen,
+		"yellow":    text.FgYellow,
+		"blue":      text.FgBlue,
+		"magenta":   text.FgMagenta,
+		"cyan":      text.FgCyan,
+		"white":     text.FgWhite,
+		"hiblack":   text.FgHiBlack,
+		"hired":     text.FgHiRed,
+		"higreen":   text.FgHiGreen,
+		"hiyellow":  text.FgHiYellow,
+		"hiblue":    text.FgHiBlue,
+		"himagenta": text.FgHiMagenta,
+		"hicyan":    text.FgHiCyan,
+		"hiwhite":   text.FgHiWhite,
+	}
+
+	// Process innermost tags first to handle nesting properly
+	result := input
+	for {
+		changed := false
+
+		// Find innermost color tag (one that doesn't contain other opening tags)
+		for i := 0; i < len(result); i++ {
+			if result[i] != '{' {
+				continue
+			}
+
+			// Find the end of this opening tag
+			closePos := strings.Index(result[i:], "}")
+			if closePos == -1 {
+				continue
+			}
+			closePos += i
+
+			colorName := result[i+1 : closePos]
+
+			// Skip if this contains a slash (it's a closing tag)
+			if strings.Contains(colorName, "/") {
+				continue
+			}
+
+			// Find the corresponding closing tag
+			closeTag := "{/" + colorName + "}"
+			closeStart := strings.Index(result[closePos+1:], closeTag)
+			if closeStart == -1 {
+				continue
+			}
+			closeStart += closePos + 1
+
+			// Check if this is innermost (no opening tags in between)
+			content := result[closePos+1 : closeStart]
+			if strings.Contains(content, "{") && !strings.HasPrefix(strings.TrimSpace(content[strings.Index(content, "{"):]), "/") {
+				// This contains other opening tags, skip for now
+				continue
+			}
+
+			// This is an innermost tag, process it
+			fullMatch := result[i : closeStart+len(closeTag)]
+
+			colorNameLower := strings.ToLower(colorName)
+			if color, exists := colorMap[colorNameLower]; exists {
+				coloredText := text.Colors{color}.Sprint(content)
+				result = strings.Replace(result, fullMatch, coloredText, 1)
+				changed = true
+				break
+			} else {
+				// If color doesn't exist, just remove the tags
+				result = strings.Replace(result, fullMatch, content, 1)
+				changed = true
+				break
+			}
+		}
+
+		if !changed {
+			break
+		}
+	}
+
+	return result
 }

--- a/forms/util_test.go
+++ b/forms/util_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2023-2024, R.I. Pienaar and the Choria Project contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package forms
+
+import (
+	"github.com/jedib0t/go-pretty/v6/text"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ColorMarkup", func() {
+	Describe("colorMarkup function", func() {
+		It("should handle no color markup", func() {
+			input := "Hello World"
+			expected := "Hello World"
+			result := colorMarkup(input)
+			Expect(result).To(Equal(expected))
+		})
+
+		It("should handle single color tag", func() {
+			input := "{red}Hello{/red} World"
+			expected := text.Colors{text.FgRed}.Sprint("Hello") + " World"
+			result := colorMarkup(input)
+			Expect(result).To(Equal(expected))
+		})
+
+		It("should handle multiple color tags", func() {
+			input := "{red}Hello{/red} {blue}World{/blue}"
+			expected := text.Colors{text.FgRed}.Sprint("Hello") + " " + text.Colors{text.FgBlue}.Sprint("World")
+			result := colorMarkup(input)
+			Expect(result).To(Equal(expected))
+		})
+
+		It("should handle nested color tags", func() {
+			input := "{red}Outer {green}Inner{/green} Text{/red}"
+			expected := text.Colors{text.FgRed}.Sprint("Outer " + text.Colors{text.FgGreen}.Sprint("Inner") + " Text")
+			result := colorMarkup(input)
+			Expect(result).To(Equal(expected))
+		})
+
+		It("should handle case insensitive colors", func() {
+			input := "{RED}Hello{/RED} {Blue}World{/Blue}"
+			expected := text.Colors{text.FgRed}.Sprint("Hello") + " " + text.Colors{text.FgBlue}.Sprint("World")
+			result := colorMarkup(input)
+			Expect(result).To(Equal(expected))
+		})
+
+		It("should handle high intensity colors", func() {
+			input := "{hired}Error{/hired} {higreen}Success{/higreen}"
+			expected := text.Colors{text.FgHiRed}.Sprint("Error") + " " + text.Colors{text.FgHiGreen}.Sprint("Success")
+			result := colorMarkup(input)
+			Expect(result).To(Equal(expected))
+		})
+
+		It("should remove invalid color tags", func() {
+			input := "{invalid}Text{/invalid}"
+			expected := "Text"
+			result := colorMarkup(input)
+			Expect(result).To(Equal(expected))
+		})
+
+		It("should handle mixed valid and invalid colors", func() {
+			input := "{red}Valid{/red} {invalid}Invalid{/invalid} {blue}Another{/blue}"
+			expected := text.Colors{text.FgRed}.Sprint("Valid") + " Invalid " + text.Colors{text.FgBlue}.Sprint("Another")
+			result := colorMarkup(input)
+			Expect(result).To(Equal(expected))
+		})
+
+		It("should handle empty color tag", func() {
+			input := "{red}{/red}"
+			expected := text.Colors{text.FgRed}.Sprint("")
+			result := colorMarkup(input)
+			Expect(result).To(Equal(expected))
+		})
+
+		It("should handle all standard colors", func() {
+			input := "{black}black{/black} {red}red{/red} {green}green{/green} {yellow}yellow{/yellow} {blue}blue{/blue} {magenta}magenta{/magenta} {cyan}cyan{/cyan} {white}white{/white}"
+			expected := text.Colors{text.FgBlack}.Sprint("black") + " " +
+				text.Colors{text.FgRed}.Sprint("red") + " " +
+				text.Colors{text.FgGreen}.Sprint("green") + " " +
+				text.Colors{text.FgYellow}.Sprint("yellow") + " " +
+				text.Colors{text.FgBlue}.Sprint("blue") + " " +
+				text.Colors{text.FgMagenta}.Sprint("magenta") + " " +
+				text.Colors{text.FgCyan}.Sprint("cyan") + " " +
+				text.Colors{text.FgWhite}.Sprint("white")
+			result := colorMarkup(input)
+			Expect(result).To(Equal(expected))
+		})
+
+		It("should handle complex nesting and preserve all text content", func() {
+			input := "{red}Start {blue}Middle {green}End{/green} More{/blue} Final{/red}"
+			result := colorMarkup(input)
+
+			// The function should process innermost tags first
+			// This is a complex case that tests the iterative processing
+			Expect(result).To(ContainSubstring("Start"))
+			Expect(result).To(ContainSubstring("Middle"))
+			Expect(result).To(ContainSubstring("End"))
+			Expect(result).To(ContainSubstring("More"))
+			Expect(result).To(ContainSubstring("Final"))
+		})
+	})
+})

--- a/go.mod
+++ b/go.mod
@@ -27,10 +27,13 @@ require (
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20250501235452-c0086092b71a // indirect
+	github.com/jedib0t/go-pretty/v6 v6.6.7 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/rivo/uniseg v0.4.7 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
 	golang.org/x/net v0.40.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec h1:qv2VnGeEQHchGaZ/u
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
+github.com/jedib0t/go-pretty/v6 v6.6.7 h1:m+LbHpm0aIAPLzLbMfn8dc3Ht8MW7lsSO4MPItz/Uuo=
+github.com/jedib0t/go-pretty/v6 v6.6.7/go.mod h1:YwC5CE4fJ1HFUDeivSV1r//AmANFHyqczZk+U6BDALU=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -45,6 +47,8 @@ github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stg
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
+github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQE9x6ikvDFZS2mDVS3drnohI=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
@@ -60,6 +64,9 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
+github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=

--- a/scaffold.go
+++ b/scaffold.go
@@ -8,14 +8,15 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/choria-io/scaffold/internal/sprig"
-	"github.com/kballard/go-shellquote"
 	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"text/template"
+
+	"github.com/choria-io/scaffold/internal/sprig"
+	"github.com/kballard/go-shellquote"
 )
 
 // Config configures a scaffolding operation
@@ -24,6 +25,8 @@ type Config struct {
 	TargetDirectory string `yaml:"target"`
 	// SourceDirectory reads templates from a directory, mutually exclusive with Source
 	SourceDirectory string `yaml:"source_directory"`
+	// MergeTargetDirectory writes into existing target directories
+	MergeTargetDirectory bool `yaml:"merge_target_directory"`
 	// Source reads templates from in-process memory
 	Source map[string]any `yaml:"source"`
 	// Post configures post-processing of files using filepath globs


### PR DESCRIPTION
Add colorMarkup function that parses color tags like {red}text{/red} and applies colors using go-pretty/text package. Supports all standard and high-intensity colors, nested tags, case-insensitive color names, and graceful handling of invalid colors.

Updates both form descriptions and property descriptions to support color markup when rendered to screen.