### PR TITLE
Fix panic on array item conditional

### DIFF
--- a/forms/forms.go
+++ b/forms/forms.go
@@ -628,6 +628,7 @@ func (p *processor) askArrayTypeProperty(prop Property, root entry) (any, error)
 
 			val := newObjectEntry(map[string]any{})
 			if _, err := scaffold.addChild(val); err != nil {
+				root.removeChild(scaffold)
 				return nil, err
 			}
 

--- a/forms/forms.go
+++ b/forms/forms.go
@@ -621,8 +621,18 @@ func (p *processor) askArrayTypeProperty(prop Property, root entry) (any, error)
 				}
 			}
 
+			scaffold := newObjectEntry(map[string]any{prop.Name: nil})
+			if _, err := root.addChild(scaffold); err != nil {
+				return nil, err
+			}
+
 			val := newObjectEntry(map[string]any{})
+			if _, err := scaffold.addChild(val); err != nil {
+				return nil, err
+			}
+
 			err := p.askProperties(prop.Properties, val, root)
+			root.removeChild(scaffold)
 			if err != nil {
 				return nil, err
 			}

--- a/forms/graph.go
+++ b/forms/graph.go
@@ -24,6 +24,7 @@ import (
 // has been set (true = value is present and valid).
 type entry interface {
 	addChild(entry) (entry, error)
+	removeChild(entry)
 	setParent(entry) error
 	value() (isSet bool, value any)
 	combinedValue() (isSet bool, value any)
@@ -64,6 +65,16 @@ func (g *graph) setParent(e entry) error {
 	g.parent = e
 
 	return nil
+}
+
+// removeChild detaches e from this node's children list.
+func (g *graph) removeChild(e entry) {
+	for i, c := range g.children {
+		if c == e {
+			g.children = append(g.children[:i], g.children[i+1:]...)
+			return
+		}
+	}
 }
 
 // hasChildren reports whether this node has any children.

--- a/forms/process_conditional_test.go
+++ b/forms/process_conditional_test.go
@@ -68,6 +68,77 @@ var _ = Describe("ProcessForm conditionals", func() {
 		Expect(res).To(Equal(map[string]any{"mode": "expert", "advanced": "extra-setting"}))
 	})
 
+	It("Should evaluate conditionals within array sub-properties", func() {
+		f := Form{
+			Description: "test",
+			Properties: []Property{
+				{
+					Name:        "things",
+					Description: "things",
+					Type:        ArrayType,
+					Required:    true,
+					Properties: []Property{
+						{Name: "choice", Description: "choice", Type: StringType, Enum: []string{"one", "two", "three"}},
+						{Name: "depends", Description: "depends", Type: StringType, Required: true, ConditionalExpression: `Input.things.choice == "one"`},
+					},
+				},
+			},
+		}
+
+		gomock.InOrder(
+			mock.EXPECT().AskOne(gomock.Any(), gomock.Any()).Return(nil),
+			// choice enum
+			mockStringResponse(mock, "one"),
+			// depends (conditional satisfied, required -> validator -> 3 args)
+			mockStringResponseV(mock, "dep-value"),
+			// "Add additional" -> no
+			mockBoolResponse(mock, false),
+		)
+
+		res, err := ProcessForm(f, nil, opts...)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).To(Equal(map[string]any{
+			"things": []any{
+				map[string]any{"choice": "one", "depends": "dep-value"},
+			},
+		}))
+	})
+
+	It("Should skip array sub-properties when conditional is false", func() {
+		f := Form{
+			Description: "test",
+			Properties: []Property{
+				{
+					Name:        "things",
+					Description: "things",
+					Type:        ArrayType,
+					Required:    true,
+					Properties: []Property{
+						{Name: "choice", Description: "choice", Type: StringType, Enum: []string{"one", "two", "three"}},
+						{Name: "depends", Description: "depends", Type: StringType, Required: true, ConditionalExpression: `Input.things.choice == "one"`},
+					},
+				},
+			},
+		}
+
+		gomock.InOrder(
+			mock.EXPECT().AskOne(gomock.Any(), gomock.Any()).Return(nil),
+			// choice enum -> "two"
+			mockStringResponse(mock, "two"),
+			// depends should be skipped since choice != "one"
+			// "Add additional" -> no
+			mockBoolResponse(mock, false),
+		)
+
+		res, err := ProcessForm(f, nil, opts...)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).To(Equal(map[string]any{
+			"things": []any{
+				map[string]any{"choice": "two"},
+			},
+		}))
+	})
+
 	It("Should reference env in conditionals", func() {
 		f := Form{
 			Description: "test",


### PR DESCRIPTION
Given this form,
```yaml
name: test
description: Test array conditional
properties:
  - name: things
    type: array
    properties:
      - name: choice
        enum: [one, two, three]
      
      - name: depends
        conditional: Input.things.choice == "one"
        required: true
```

it panics on `depends`:
```
Test array conditional

? Press enter to start 
? Add first 'things' entry Yes



? choice one
error: cannot fetch choice from <nil> (1:14)
 | Input.things.choice == "one"
 | .............^
exit status 1
```